### PR TITLE
Correction of incorrect docstrings for freezing of layers

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -190,7 +190,7 @@ class Learner():
         self.layer_groups = split_model(self.model, split_on)
 
     def freeze_to(self, n:int)->None:
-        "Freeze layers up to layer `n`."
+        "Freeze layers up to layer group `n`."
         for g in self.layer_groups[:n]:
             for l in g:
                 if not self.train_bn or not isinstance(l, bn_types): requires_grad(l, False)
@@ -198,7 +198,7 @@ class Learner():
         self.create_opt(defaults.lr)
 
     def freeze(self)->None:
-        "Freeze up to last layer."
+        "Freeze up to last layer group."
         assert(len(self.layer_groups)>1)
         self.freeze_to(-1)
         self.create_opt(defaults.lr)


### PR DESCRIPTION
In the docstring for fastai.basic_train.freeze() it was written that the function will “freeze up to last layer”. What actually happens is that the function freezes up to last layer group.
In the docstring for fastai.basic_train.freeze_to(n:int) it was written that the function will “freeze layers up to layer n”. What actually happens is that the function freezes up to layer group n.
Both have been corrected.
